### PR TITLE
Allow empty default CPU architecture

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -126,6 +126,7 @@ NSYNC_OPTS_GENERIC = select({
     ":android_arm": ["-I" + pkg_path_name() + "/platform/arm"],
     ":android_arm64": ["-I" + pkg_path_name() + "/platform/aarch64"],
     ":msvc_windows_x86_64": ["-I" + pkg_path_name() + "/platform/x86_64"],
+    "//conditions:default": [],
 }) + [
     "-I" + pkg_path_name() + "/public",
     "-I" + pkg_path_name() + "/internal",


### PR DESCRIPTION
This is to allow building on non-conventional CPU architectures (or simply CPU architectures with a developing software ecosystem, such as RISC-V).