### PR TITLE
Patch 1

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -43,7 +43,7 @@ config_setting(
 
 config_setting(
     name = "gcc_linux_aarch64",
-    values = {"cpu": "arm"},
+    values = {"cpu": "aarch64"},
 )
 
 config_setting(

--- a/bazel/bazel_BUILD
+++ b/bazel/bazel_BUILD
@@ -43,7 +43,7 @@ config_setting(
 
 config_setting(
     name = "gcc_linux_aarch64",
-    values = {"cpu": "arm"},
+    values = {"cpu": "aarch64"},
 )
 
 config_setting(


### PR DESCRIPTION
Our team at Arm Inc. tested Tensorflow that has a dependency on nsync. We found that the cpu type has to be "aarch64" instead of "arm" for correct compilation on aarch64 servers.