### PR TITLE
Reset thread local waiter address to NULL before recycling it.

### DIFF
--- a/internal/common.c
+++ b/internal/common.c
@@ -143,13 +143,13 @@ static nsync_atomic_uint32_ free_waiters_mu; /* spinlock; protects free_waiters 
 
 static THREAD_LOCAL waiter *waiter_for_thread;
 static void waiter_destroy (void *v) {
+	waiter *w = (waiter *) v;
 	// Reset waiter_for_thread in case another thread-local variable reuses
 	// the waiter in its destructor while the waiter is taken by the other
 	// thread from free_waiters. This can happen as the destruction order
 	// of thread-local variables can be arbitrary in some platform e.g.
 	// POSIX.
 	waiter_for_thread = NULL;
-	waiter *w = (waiter *) v;
 	IGNORE_RACES_START ();
 	ASSERT ((w->flags & (WAITER_RESERVED|WAITER_IN_USE)) == WAITER_RESERVED);
 	w->flags &= ~WAITER_RESERVED;

--- a/internal/common.c
+++ b/internal/common.c
@@ -143,6 +143,12 @@ static nsync_atomic_uint32_ free_waiters_mu; /* spinlock; protects free_waiters 
 
 static THREAD_LOCAL waiter *waiter_for_thread;
 static void waiter_destroy (void *v) {
+	// Reset waiter_for_thread in case another thread-local variable reuses
+	// the waiter in its destructor while the waiter is taken by the other
+	// thread from free_waiters. This can happen as the destruction order
+	// of thread-local variables can be arbitrary in some platform e.g.
+	// POSIX.
+	waiter_for_thread = NULL;
 	waiter *w = (waiter *) v;
 	IGNORE_RACES_START ();
 	ASSERT ((w->flags & (WAITER_RESERVED|WAITER_IN_USE)) == WAITER_RESERVED);

--- a/internal/common.c
+++ b/internal/common.c
@@ -144,11 +144,11 @@ static nsync_atomic_uint32_ free_waiters_mu; /* spinlock; protects free_waiters 
 static THREAD_LOCAL waiter *waiter_for_thread;
 static void waiter_destroy (void *v) {
 	waiter *w = (waiter *) v;
-	// Reset waiter_for_thread in case another thread-local variable reuses
-	// the waiter in its destructor while the waiter is taken by the other
-	// thread from free_waiters. This can happen as the destruction order
-	// of thread-local variables can be arbitrary in some platform e.g.
-	// POSIX.
+	/* Reset waiter_for_thread in case another thread-local variable reuses
+	   the waiter in its destructor while the waiter is taken by the other
+	   thread from free_waiters. This can happen as the destruction order
+	   of thread-local variables can be arbitrary in some platform e.g.
+	   POSIX.  */
 	waiter_for_thread = NULL;
 	IGNORE_RACES_START ();
 	ASSERT ((w->flags & (WAITER_RESERVED|WAITER_IN_USE)) == WAITER_RESERVED);


### PR DESCRIPTION
This PR fixes a concurrent issue that two threads can potentially share the same waiter object and cause SIGSEGV or deadlock.

### Summary
Destruction order of thread-local variables is not defined in [POSIX](https://linux.die.net/man/3/pthread_key_create). Per-thread waiter can be destructed and reused by another thread-local variable in its destructor. At the same time, the waiter can have been recycled and reserved by another thread. Hence, two threads share the same waiter objects and cause concurrency issue.

### Environment
OS Platform and Distribution: Linux 5.4.111.1 x86_64
GCC/Compiler version: devtoolset-7
Platform: POSIX

### Details
Our [TensorFlow](https://github.com/tensorflow/tensorflow) application which uses nsync for mutex/cv implementation failed because of SIGSEGV. The issue can only be reproduced during thread pool destruction. After adding logs into nsync library, we are able to identify the root cause.

For example, the following logs show two threads(_0x7f4118748700_ and _0x7f4100718700_) share the same waiter object (_0x7f465c2c2290_) and cause SIGSEGV. First, the [waiter_destroy](https://github.com/google/nsync/blob/712e51fc50fee7c609a6ed38639288bd6030e876/internal/common.c#L150) was called on thread _0x7f4118748700_ and the waiter _0x7f465c2c2290_ had been recycled into free_waiters. At this moment,  thread _0x7f4100718700_ enter the [nsync_waiter_new_](https://github.com/google/nsync/blob/712e51fc50fee7c609a6ed38639288bd6030e876/internal/common.c#L182) function and take the waiter from free_waiters. Then, thread _0x7f4118748700_ enter [nsync_waiter_new_](https://github.com/google/nsync/blob/712e51fc50fee7c609a6ed38639288bd6030e876/internal/common.c#L171) again. Because the thread-local `waiter_for_thread` is not cleaned up, it assumes the waiter object is still reserved by itself. (Although the reserved bit was cleaned up in waiter_destroy, thread _0x7f4100718700_ reserved the waiter and reset the reserved bit. However, the in-use bit was not set yet.) After that both threads set the in-use bit and leave nsync_waiter_new_ function. When two threads hold the same waiter object, the object was freed twice and failed the [assertion](https://github.com/google/nsync/blob/712e51fc50fee7c609a6ed38639288bd6030e876/internal/common.c#L216) in `nsync_waiter_free_`.

> [nsync] waiter_destroy(internal/common.c#L150)  tid 0x7f4118748700, w 0x7f465c2c2290
[nsync] nsync_waiter_new_(internal/common.c#L182) tid 0x7f4100718700, w 0x7f465c2c2290 
[nsync] nsync_waiter_new_(internal/common.c#L171) tid 0x7f4118748700, tw 0x7f465c2c2290
[nsync] nsync_waiter_new_((internal/common.c#L206) tid 0x7f4100718700, w 0x7f465c2c2290
[nsync] nsync_mu_lock_slow_(internal/mu.c#L102) tid 0x7f4118748700, mu 0x12482b40, waiter 0x7f465c2c2290
[nsync] nsync_mu_lock_slow_(internal/mu.c#L71) tid 0x7f4100718700, mu 0x7f4ae4593f30, waiter 0x7f465c2c2290
[nsync] nsync_mu_lock_slow_(internal/mu.c#L71) tid 0x7f4118748700, mu 0x12482b40, waiter 0x7f465c2c2290
\# A fatal error has been detected by the Java Runtime Environment:
\#
\#  SIGSEGV (0xb) at pc=0x00007f4af0e74eda, pid=6, tid=0x00007f4118748700
\#
\# JRE version: Java(TM) SE Runtime Environment (8.0_172-b11) (build 1.8.0_172-b11)
\# Java VM: Java HotSpot(TM) 64-Bit Server VM (25.172-b11 mixed mode linux-amd64 compressed oops)
\# Problematic frame:
\# C  [_pywrap_tensorflow_internal.so+0xc8cbeda] nsync::nsync_waiter_free_(nsync::waiter*)+0xa
\#
\# Core dump written. Default location: /opt/code-fetcher-system/src/core or core.6
\#
\# An error report file with more information is saved as:
\# /opt/code-fetcher-system/src/hs_err_pid6.log

Deadlock can also happen when the waiter is moved to another mutex before it got notified. For example, two threads above were locked on two different mutex (_0x12482b40_ and _0x7f4ae4593f30_). In this case, the waiter semaphore is decremented twice but only incremented once. 

_P.S. The thread-local variable that access locks in its [destructor](https://github.com/tensorflow/tensorflow/blob/v2.8.0/tensorflow/core/profiler/internal/cpu/traceme_recorder.cc#L320) in TensorFlow is the per-thread [TraceMeRecorder::ThreadLocalRecorderWrapper](https://github.com/tensorflow/tensorflow/blob/v2.8.0/tensorflow/core/profiler/internal/cpu/traceme_recorder.cc#L381) used in TensorFlow profiler._

### Proposed solution
Since the destruction order is not guaranteed in POSIX thread, reset waiter_for_thread to NULL so that the thread will not access invalid waiter address even the waiter has been destructed. The side effect is that the per-thread waiter can be created and destructed many times. And, it may potentially go beyond the destruction limits i.e. PTHREAD_DESTRUCTOR_ITERATIONS depends on the pthread implementation.

### Testing
make && make test
Tested with internal application and verified the issue was fixed.