### PR TITLE
Strengthen memory barrier on designated waker

### DIFF
--- a/internal/mu.c
+++ b/internal/mu.c
@@ -297,8 +297,8 @@ void nsync_mu_unlock_slow_ (nsync_mu *mu, lock_type *l_type) {
 				return;
 			}
 		} else if ((old_word&MU_SPINLOCK) == 0 &&
-			   ATM_CAS_ACQ (&mu->word, old_word,
-					(old_word-early_release_mu)|MU_SPINLOCK|MU_DESIG_WAKER)) {
+			   ATM_CAS_RELACQ (&mu->word, old_word,
+                                           (old_word-early_release_mu)|MU_SPINLOCK|MU_DESIG_WAKER)) {
 			nsync_dll_list_ wake;
 			lock_type *wake_type;
 			uint32_t clear_on_release;


### PR DESCRIPTION
This change makes *NSYNC work correctly for me on the Apple M1 microprocessor when compiling my code with GCC targeting the ARMv8.0A microarchitecture. I have no idea if this is a bug with *NSYNC or a bug with the portable ISA that's provided by the Apple M1. What I do know is that (1) this change solves it, and (2) I can't reproduce the issue on Apple M2 and x86-64.

```diff
@@ -412,7 +413,7 @@
   b0:  885ffe64        ldaxr   w4, [x19]
   b4:  6b02009f        cmp     w4, w2
   b8:  54000061        b.ne    c4 <nsync_mu_unlock_slow_+0xc4>  // b.any
-  bc:  88057e63        stxr    w5, w3, [x19]
+  bc:  8805fe63        stlxr   w5, w3, [x19]
   c0:  35ffff85        cbnz    w5, b0 <nsync_mu_unlock_slow_+0xb0>
   c4:  54fffe61        b.ne    90 <nsync_mu_unlock_slow_+0x90>  // b.any
   c8:  7100003f        cmp     w1, #0x0
```

See also https://github.com/jart/cosmopolitan/commit/751d20d98da3b9fa5b352da48c71c64c713a8904

---

Re: `nsync/CONTRIBUTING`, I'm not sure if I have a CLA on file since https://cla.developers.google.com/clas is down. Although I used to work for Google (on the same team as you actually) so maybe that counts?