### PR TITLE
build: Add export targets for nsync and nsync_cpp in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,11 +400,11 @@ endif ()
 
 set (CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
 
-install (TARGETS nsync
+install (TARGETS nsync EXPORT nsync
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development)
 
-install (TARGETS nsync_cpp OPTIONAL
+install (TARGETS nsync_cpp EXPORT nsync_cpp OPTIONAL
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development)
 
@@ -429,3 +429,11 @@ foreach (NSYNC_INCLUDE ${NSYNC_INCLUDES})
 		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 		COMPONENT Development)
 endforeach ()
+
+install(EXPORT nsync
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/nsync
+        FILE        nsyncConfig.cmake)
+
+install(EXPORT nsync_cpp
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/nsync_cpp
+        FILE        nsync_cppConfig.cmake)


### PR DESCRIPTION
adopt the build patch in here, https://gitlab.archlinux.org/archlinux/packaging/packages/nsync/-/commit/c7526aec9773890ce798b029efef48921e004124, would help with onnxruntime 1.17.3 on homebrew side (https://github.com/Homebrew/homebrew-core/pull/169254)