### PR TITLE
Add support for bzlmod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+bazel-*
+MODULE.bazel.lock

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "nsync",
+    version = "0",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "platforms", version = "0.0.10")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,6 @@
 module(
     name = "nsync",
     version = "0",
-    compatibility_level = 0,
 )
 
 bazel_dep(name = "platforms", version = "0.0.10")

--- a/bazel/pkg_path_name.bzl
+++ b/bazel/pkg_path_name.bzl
@@ -4,5 +4,5 @@
 # (This is used to recover the directory name to pass to cc -I<dir>, when
 # choosing from among alternative header files for different platforms.)
 def pkg_path_name():
-    return "./" + Label(native.repository_name() + "//" + native.package_name() +
+    return "./" + Label("//" + native.package_name() +
                         ":nsync").workspace_root + "/" + native.package_name()


### PR DESCRIPTION
This adds support for bazel's new dependency management setup. The changes required for this repo are very minimal. I verified that they also still worked with bazel 6.x and without bzlmod.