### PR TITLE
Update usage of deprecated ATOMIC_VAR_INIT

### DIFF
--- a/public/nsync_atomic.h
+++ b/public/nsync_atomic.h
@@ -45,7 +45,7 @@ NSYNC_CPP_END_
 NSYNC_CPP_START_
 typedef std::atomic<uint32_t> nsync_atomic_uint32_;
 NSYNC_CPP_END_
-#define NSYNC_ATOMIC_UINT32_INIT_ (std::atomic<uint32_t> (0))
+#define NSYNC_ATOMIC_UINT32_INIT_ { 0 }
 #define NSYNC_ATOMIC_UINT32_LOAD_(p) (std::atomic_load (p))
 #define NSYNC_ATOMIC_UINT32_STORE_(p,v) (std::atomic_store ((p), (uint32_t) (v)))
 #define NSYNC_ATOMIC_UINT32_PTR_(p) (p)

--- a/public/nsync_atomic.h
+++ b/public/nsync_atomic.h
@@ -45,7 +45,7 @@ NSYNC_CPP_END_
 NSYNC_CPP_START_
 typedef std::atomic<uint32_t> nsync_atomic_uint32_;
 NSYNC_CPP_END_
-#define NSYNC_ATOMIC_UINT32_INIT_ ATOMIC_VAR_INIT (0)
+#define NSYNC_ATOMIC_UINT32_INIT_ (std::atomic<uint32_t> (0))
 #define NSYNC_ATOMIC_UINT32_LOAD_(p) (std::atomic_load (p))
 #define NSYNC_ATOMIC_UINT32_STORE_(p,v) (std::atomic_store ((p), (uint32_t) (v)))
 #define NSYNC_ATOMIC_UINT32_PTR_(p) (p)


### PR DESCRIPTION
`ATOMIC_VAR_INIT` is deprecated in C++20.

From [here](https://en.cppreference.com/w/cpp/atomic/ATOMIC_VAR_INIT):

    This macro is primarily provided for compatibility with C; it behaves the same as the constructor of std::atomic.

This change replaces it with a call to the `std::atomic<uint32_t>` constructor via brace initialization.


More context:
I'm working on a project that includes nsync headers and I'm seeing deprecation warnings from this `ATOMIC_VAR_INIT` usage after updating my compiler.