### PR TITLE
Fix building shared library on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,6 @@ elseif ("${CMAKE_SYSTEM_NAME}X" STREQUAL "DarwinX")
 		${NSYNC_OS_CPP_SRC}
 		"platform/c++11/src/nsync_semaphore_mutex.cc"
 		"platform/posix/src/clock_gettime.c"
-		"platform/posix/src/nsync_semaphore_mutex.c"
 	)
 elseif ("${CMAKE_SYSTEM_NAME}X" STREQUAL "LinuxX")
 	set (NSYNC_POSIX ON)


### PR DESCRIPTION
Having both C and C++ source caused duplicate symbols while linking:
```
duplicate symbol 'nsync::nsync_mu_semaphore_v(nsync::nsync_semaphore_s_*)'
```