### PR TITLE
Include <chrono> for system_clock

### DIFF
--- a/platform/c++11/platform.h
+++ b/platform/c++11/platform.h
@@ -16,6 +16,7 @@
 #define NSYNC_PLATFORM_CPP11_PLATFORM_H_
 
 /* These C header files are in "C compatibility headers" in C++11. */
+#include <chrono>
 #include <string.h>
 #include <errno.h>
 #include <stdlib.h>


### PR DESCRIPTION
I work on Microsoft Visual C++ testing, where we regularly build popular open-source projects, including yours, with development builds of our compiler and libraries to detect and prevent shipping regressions that would affect you. This also allows us to provide advance notice of breaking changes, which is the case here.

Recently this commit https://github.com/microsoft/STL/pull/5105 is revealing an issue in PrusaSlicer.

Compiler error with this STL change:
```
./external/nsync//platform/c++11\platform.h(67): error C2039: 'system_clock': is not a member of 'std::chrono'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\__msvc_chrono.hpp(286): note: see declaration of 'std::chrono'
./external/nsync//platform/c++11\platform.h(67): error C3083: 'system_clock': the symbol to the left of a '::' must be a type
./external/nsync//platform/c++11\platform.h(67): error C2133: 'epoch': unknown size
./external/nsync//platform/c++11\platform.h(67): error C2512: 'std::chrono::time_point': no appropriate default constructor available
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.42.34433\include\__msvc_chrono.hpp(200): note: see declaration of 'std::chrono::time_point'
./external/nsync//platform/c++11\platform.h(69): error C2676: binary '+': 'std::chrono::time_point' does not define this operator or a conversion to a type acceptable to the predefined operator
```

Affected code:
https://github.com/google/nsync/blob/c6205171f084c0d3ce3ff51f1d7da8e9aa60d11e/platform/c%2B%2B11/platform.h#L67-L71

This was assuming that including <thread> makes the chrono::system_clock type available, which is not guaranteed by the Standard. You must explicitly include <chrono>.