### PR TITLE
Bump minimal required version for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.12...4.0)
 
 # nsync provides portable synchronization primitives, such as mutexes and
 # condition variables.


### PR DESCRIPTION
CMake 4, released half a year ago, [has dropped compatibility with versions older than 3.5](https://cmake.org/cmake/help/v4.0/release/4.0.html#deprecated-and-removed-features).

This patch bumps the minimal required version of CMake to 3.10.

I've set it to 3.10, so it doesn’t get deprecated as soon as 3.5 will be, and yet doesn’t impose a too new CMake release to build. For reference, [the oldest maintained LTS debian already has 3.18](https://packages.debian.org/bullseye/cmake).

This issue has come up recently on [nixpkgs](https://nixos.org), where a migration to CMake 4 is underway. See NixOS/nixpkgs/issues/445447 for reference.